### PR TITLE
fix(ossm): do not inject oauth-proxy to notebooks

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@
 
 ############### Default settings ###############
 BACKEND_PORT=8080
-IMAGE_REPOSITORY=quay.io/maistra-dev/odh-dashboard:maistra-dev
+IMAGE_REPOSITORY=quay.io/opendatahub/odh-dashboard:nightly
 DOC_LINK ='https://opendatahub.io/docs.html'
 COMMUNITY_LINK ='https://opendatahub.io/community.html'
 ENABLED_APPS_CM = 'odh-enabled-applications-config'

--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@
 
 ############### Default settings ###############
 BACKEND_PORT=8080
-IMAGE_REPOSITORY=quay.io/opendatahub/odh-dashboard:nightly
+IMAGE_REPOSITORY=quay.io/maistra-dev/odh-dashboard:maistra-dev
 DOC_LINK ='https://opendatahub.io/docs.html'
 COMMUNITY_LINK ='https://opendatahub.io/community.html'
 ENABLED_APPS_CM = 'odh-enabled-applications-config'

--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -438,7 +438,6 @@ export const createNotebook = async (
     notebookAssembled.metadata.annotations = {};
   }
 
-  notebookAssembled.metadata.annotations['notebooks.opendatahub.io/inject-oauth'] = 'false';
   const notebookContainers = notebookAssembled.spec.template.spec.containers;
 
   if (!notebookContainers[0]) {

--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -438,7 +438,7 @@ export const createNotebook = async (
     notebookAssembled.metadata.annotations = {};
   }
 
-  notebookAssembled.metadata.annotations['notebooks.opendatahub.io/inject-oauth'] = 'true';
+  notebookAssembled.metadata.annotations['notebooks.opendatahub.io/inject-oauth'] = 'false';
   const notebookContainers = notebookAssembled.spec.template.spec.containers;
 
   if (!notebookContainers[0]) {

--- a/frontend/src/api/network/notebooks.ts
+++ b/frontend/src/api/network/notebooks.ts
@@ -63,7 +63,6 @@ const assembleNotebook = (data: StartNotebookData, username: string): NotebookKi
         'notebooks.opendatahub.io/oauth-logout-url': `${origin}/projects/${projectName}?notebookLogout=${notebookId}`,
         'notebooks.opendatahub.io/last-size-selection': notebookSize.name,
         'notebooks.opendatahub.io/last-image-selection': imageSelection,
-        'notebooks.opendatahub.io/inject-oauth': 'false',
         'opendatahub.io/username': username,
       },
       name: notebookId,

--- a/frontend/src/api/network/notebooks.ts
+++ b/frontend/src/api/network/notebooks.ts
@@ -63,7 +63,7 @@ const assembleNotebook = (data: StartNotebookData, username: string): NotebookKi
         'notebooks.opendatahub.io/oauth-logout-url': `${origin}/projects/${projectName}?notebookLogout=${notebookId}`,
         'notebooks.opendatahub.io/last-size-selection': notebookSize.name,
         'notebooks.opendatahub.io/last-image-selection': imageSelection,
-        'notebooks.opendatahub.io/inject-oauth': 'true',
+        'notebooks.opendatahub.io/inject-oauth': 'false',
         'opendatahub.io/username': username,
       },
       name: notebookId,


### PR DESCRIPTION
ODH-dashboard was overwriting the notebook metadata to always inject oauth into the notebooks, this reverses that to never inject oauth-proxy into the notebooks. 