### PR TITLE
(feat) add disableServiceMesh flag, link to notebooks through mesh, disable oauth-proxy injection

### DIFF
--- a/backend/src/routes/api/notebooks/utils.ts
+++ b/backend/src/routes/api/notebooks/utils.ts
@@ -27,7 +27,7 @@ export const getNotebookStatus = async (
   const notebookName = notebook?.metadata.name;
   let newNotebook: Notebook;
   if (isRunning && !notebook?.metadata.annotations?.['opendatahub.io/link']) {
-    const route = await getRoute(fastify, namespace, notebookName).catch((e) => {
+    const route = await getRoute(fastify, "istio-system", "opendatahub-odh-gateway-525eca1d5089dbdc").catch((e) => {
       fastify.log.warn(`Failed getting route ${notebookName}: ${e.message}`);
       return undefined;
     });
@@ -78,7 +78,7 @@ export const patchNotebookRoute = async (
   const patch: RecursivePartial<Notebook> = {
     metadata: {
       annotations: {
-        'opendatahub.io/link': `https://${route.spec.host}/notebook/${namespace}/${name}`,
+        'opendatahub.io/link': `https://${route.spec.host}/notebook/${namespace}/${name}/`,
       },
     },
   };

--- a/backend/src/routes/api/notebooks/utils.ts
+++ b/backend/src/routes/api/notebooks/utils.ts
@@ -3,12 +3,14 @@ import { PatchUtils, V1ContainerStatus, V1Pod, V1PodList } from '@kubernetes/cli
 import { createCustomError } from '../../../utils/requestUtils';
 import { getUserName } from '../../../utils/userUtils';
 import { RecursivePartial } from '../../../typeHelpers';
+import { getDashboardConfig } from '../../../utils/resourceUtils';
 import {
   createNotebook,
   generateNotebookNameFromUsername,
   getNamespaces,
   getNotebook,
   getRoute,
+  getGatewayRoute,
   updateNotebook,
 } from '../../../utils/notebookUtils';
 import { FastifyRequest } from 'fastify';
@@ -27,10 +29,19 @@ export const getNotebookStatus = async (
   const notebookName = notebook?.metadata.name;
   let newNotebook: Notebook;
   if (isRunning && !notebook?.metadata.annotations?.['opendatahub.io/link']) {
-    const route = await getRoute(fastify, "istio-system", "opendatahub-odh-gateway-525eca1d5089dbdc").catch((e) => {
-      fastify.log.warn(`Failed getting route ${notebookName}: ${e.message}`);
-      return undefined;
-    });
+    const disableServiceMesh = getDashboardConfig().spec.dashboardConfig.disableServiceMesh;
+    let route: Route;
+    if (!disableServiceMesh) {
+      route = await getGatewayRoute(fastify, 'istio-system', 'odh-gateway').catch((e) => {
+        fastify.log.warn(`Failed getting route ${notebookName}: ${e.message}`);
+        return undefined;
+      });
+    } else {
+      route = await getRoute(fastify, namespace, notebookName).catch((e) => {
+        fastify.log.warn(`Failed getting route ${notebookName}: ${e.message}`);
+        return undefined;
+      });
+    }
     if (route) {
       newNotebook = await patchNotebookRoute(fastify, route, namespace, notebookName).catch((e) => {
         fastify.log.warn(`Failed patching route to notebook ${notebookName}: ${e.message}`);

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -18,6 +18,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableUserManagement: boolean;
       disableProjects: boolean;
       disableModelServing: boolean;
+      disableServiceMesh: boolean;
       modelMetricsNamespace: string;
     };
     groupsConfig?: {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -46,6 +46,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableUserManagement: false,
       disableProjects: false,
       disableModelServing: false,
+      disableServiceMesh: true,
       modelMetricsNamespace: '',
     },
     notebookController: {

--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -491,6 +491,8 @@ export const createNotebook = async (
   // If not using service mesh, continue to inject oauth container.
   if (config.spec.dashboardConfig.disableServiceMesh) {
     notebookAssembled.metadata.annotations['notebooks.opendatahub.io/inject-oauth'] = 'true';
+  } else {
+    notebookAssembled.metadata.annotations['notebooks.opendatahub.io/inject-oauth'] = 'false';
   }
 
   const notebookContainers = notebookAssembled.spec.template.spec.containers;

--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -461,6 +461,8 @@ export const createNotebook = async (
   url: string,
   notebookData?: NotebookData,
 ): Promise<Notebook> => {
+  const config = getDashboardConfig();
+
   if (!notebookData) {
     const error = createCustomError(
       'Missing Notebook',
@@ -484,6 +486,11 @@ export const createNotebook = async (
 
   if (!notebookAssembled?.metadata?.annotations) {
     notebookAssembled.metadata.annotations = {};
+  }
+
+  // If not using service mesh, continue to inject oauth container.
+  if (config.spec.dashboardConfig.disableServiceMesh) {
+    notebookAssembled.metadata.annotations['notebooks.opendatahub.io/inject-oauth'] = 'true';
   }
 
   const notebookContainers = notebookAssembled.spec.template.spec.containers;

--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -438,7 +438,6 @@ export const createNotebook = async (
     notebookAssembled.metadata.annotations = {};
   }
 
-  notebookAssembled.metadata.annotations['notebooks.opendatahub.io/inject-oauth'] = 'true';
   const notebookContainers = notebookAssembled.spec.template.spec.containers;
 
   if (!notebookContainers[0]) {

--- a/docs/dashboard_config.md
+++ b/docs/dashboard_config.md
@@ -17,6 +17,7 @@ The following are a list of features that are supported, along with there defaul
 |  disableISVBadges | false | Removes the badge that indicate if a product is ISV or not.
 |  disableAppLauncher | false | Removes the application launcher that is used in OKD environments
 |  disableUserManagement | false | Removes the User Management panel in Settings.
+|  disableServiceMesh | true | Disables use of service mesh for routing and authorization.
 
 ## Defaults
 

--- a/frontend/src/api/network/notebooks.ts
+++ b/frontend/src/api/network/notebooks.ts
@@ -63,7 +63,6 @@ const assembleNotebook = (data: StartNotebookData, username: string): NotebookKi
         'notebooks.opendatahub.io/oauth-logout-url': `${origin}/projects/${projectName}?notebookLogout=${notebookId}`,
         'notebooks.opendatahub.io/last-size-selection': notebookSize.name,
         'notebooks.opendatahub.io/last-image-selection': imageSelection,
-        'notebooks.opendatahub.io/inject-oauth': 'true',
         'opendatahub.io/username': username,
       },
       name: notebookId,

--- a/frontend/src/api/network/notebooks.ts
+++ b/frontend/src/api/network/notebooks.ts
@@ -69,9 +69,9 @@ const assembleNotebook = (
         'notebooks.opendatahub.io/last-size-selection': notebookSize.name,
         'notebooks.opendatahub.io/last-image-selection': imageSelection,
         // Add the inject oauth annotation if use of Service Mesh is disabled
-        ...(dashboardConfig.spec.dashboardConfig.disableServiceMesh && {
-          'notebooks.opendatahub.io/inject-oauth': 'true',
-        }),
+        ...(dashboardConfig.spec.dashboardConfig.disableServiceMesh
+          ? { 'notebooks.opendatahub.io/inject-oauth': 'true' }
+          : { 'notebooks.opendatahub.io/inject-oauth': 'false' }),
         'opendatahub.io/username': username,
       },
       name: notebookId,

--- a/frontend/src/api/network/routes.ts
+++ b/frontend/src/api/network/routes.ts
@@ -5,3 +5,13 @@ import { RouteKind } from '../../k8sTypes';
 export const getRoute = (name: string, namespace: string): Promise<RouteKind> => {
   return k8sGetResource<RouteKind>({ model: RouteModel, queryOptions: { name, ns: namespace } });
 };
+
+export const getGatewayRoute = (namespace: string, gatewayName: string): Promise<RouteKind | null> => {
+  const labelSelector = `maistra.io/gateway-name=${gatewayName}`;
+  const queryOptions = {
+    ns: namespace,
+    labelSelector,
+  };
+  return k8sGetResource<RouteKind>({ model: RouteModel, queryOptions })
+    .catch(() => null); // Catch errors and return null
+};

--- a/frontend/src/api/network/routes.ts
+++ b/frontend/src/api/network/routes.ts
@@ -1,6 +1,7 @@
 import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { RouteModel } from '../models';
-import { RouteKind } from '../../k8sTypes';
+import { RouteKind, RouteList } from '../../k8sTypes';
+
 
 export const getRoute = (name: string, namespace: string): Promise<RouteKind> => {
   return k8sGetResource<RouteKind>({ model: RouteModel, queryOptions: { name, ns: namespace } });
@@ -12,6 +13,11 @@ export const getGatewayRoute = (namespace: string, gatewayName: string): Promise
     ns: namespace,
     labelSelector,
   };
-  return k8sGetResource<RouteKind>({ model: RouteModel, queryOptions })
-    .catch(() => null); // Catch errors and return null
+  return k8sGetResource<RouteList>({ model: RouteModel, queryOptions })
+    .then((response) => {
+      console.log(response)
+      const routes = response.items.filter((route) => route.metadata?.labels?.['maistra.io/gateway-name'] === gatewayName);
+      return routes.length > 0 ? routes[0] : null;
+    })
+    .catch(() => null);
 };

--- a/frontend/src/api/network/routes.ts
+++ b/frontend/src/api/network/routes.ts
@@ -1,6 +1,6 @@
 import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { RouteModel } from '../models';
-import { RouteKind, RouteList } from '../../k8sTypes';
+import { RouteKind, List } from '../../k8sTypes';
 
 export const getRoute = (name: string, namespace: string): Promise<RouteKind> => {
   return k8sGetResource<RouteKind>({ model: RouteModel, queryOptions: { name, ns: namespace } });
@@ -15,7 +15,7 @@ export const getGatewayRoute = (
     ns: namespace,
     labelSelector,
   };
-  return k8sGetResource<RouteList>({ model: RouteModel, queryOptions })
+  return k8sGetResource<List<RouteKind>>({ model: RouteModel, queryOptions })
     .then((response) => {
       const routes = response.items.filter(
         (route) => route.metadata?.labels?.['maistra.io/gateway-name'] === gatewayName,

--- a/frontend/src/api/network/routes.ts
+++ b/frontend/src/api/network/routes.ts
@@ -2,12 +2,14 @@ import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { RouteModel } from '../models';
 import { RouteKind, RouteList } from '../../k8sTypes';
 
-
 export const getRoute = (name: string, namespace: string): Promise<RouteKind> => {
   return k8sGetResource<RouteKind>({ model: RouteModel, queryOptions: { name, ns: namespace } });
 };
 
-export const getGatewayRoute = (namespace: string, gatewayName: string): Promise<RouteKind | null> => {
+export const getGatewayRoute = (
+  namespace: string,
+  gatewayName: string,
+): Promise<RouteKind | null> => {
   const labelSelector = `maistra.io/gateway-name=${gatewayName}`;
   const queryOptions = {
     ns: namespace,
@@ -15,8 +17,9 @@ export const getGatewayRoute = (namespace: string, gatewayName: string): Promise
   };
   return k8sGetResource<RouteList>({ model: RouteModel, queryOptions })
     .then((response) => {
-      console.log(response)
-      const routes = response.items.filter((route) => route.metadata?.labels?.['maistra.io/gateway-name'] === gatewayName);
+      const routes = response.items.filter(
+        (route) => route.metadata?.labels?.['maistra.io/gateway-name'] === gatewayName,
+      );
       return routes.length > 0 ? routes[0] : null;
     })
     .catch(() => null);

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -347,6 +347,12 @@ export type RouteKind = K8sResourceCommon & {
   };
 };
 
+export type RouteList = {
+  apiVersion: string;
+  kind: 'RouteList';
+  items: RouteKind[];
+};
+
 export type SecretKind = K8sResourceCommon & {
   metadata: {
     name: string;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -347,11 +347,12 @@ export type RouteKind = K8sResourceCommon & {
   };
 };
 
-export type RouteList = {
-  apiVersion: string;
-  kind: 'RouteList';
-  items: RouteKind[];
-};
+export type List<T> = {
+  apiVersion?: string;
+  kind?: string;
+  metadata: Record<string, unknown>;
+  items: T[];
+} & K8sResourceCommon;
 
 export type SecretKind = K8sResourceCommon & {
   metadata: {

--- a/frontend/src/pages/projects/notebook/useRouteForNotebook.ts
+++ b/frontend/src/pages/projects/notebook/useRouteForNotebook.ts
@@ -23,7 +23,7 @@ const useRouteForNotebook = (
         // execute getRoute if the feature flag is set to true
         const getRoutePromise = dashboardConfig.spec.dashboardConfig.disableServiceMesh
           ? getRoute(notebookName, projectName)
-          : getGatewayRoute("istio-system", "odh-gateway");
+          : getGatewayRoute('istio-system', 'odh-gateway');
 
         getRoutePromise
           .then((route) => {
@@ -48,7 +48,7 @@ const useRouteForNotebook = (
       cancelled = true;
       clearTimeout(watchHandle);
     };
-  }, [notebookName, projectName]);
+  }, [notebookName, projectName, dashboardConfig]);
 
   return [route, loaded, loadError];
 };

--- a/frontend/src/pages/projects/notebook/useRouteForNotebook.ts
+++ b/frontend/src/pages/projects/notebook/useRouteForNotebook.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getRoute } from '../../../api';
+import { getGatewayRoute, getRoute } from '../../../api';
 import { FAST_POLL_INTERVAL } from '../../../utilities/const';
 
 const useRouteForNotebook = (
@@ -10,7 +10,6 @@ const useRouteForNotebook = (
   const [loaded, setLoaded] = React.useState(false);
   const [loadError, setLoadError] = React.useState<Error | null>(null);
 
-  // ISTIO TODO: investigate where this is used, change link to istiofied.
   React.useEffect(() => {
     let watchHandle;
     let cancelled = false;
@@ -19,12 +18,12 @@ const useRouteForNotebook = (
         return;
       }
       if (notebookName && projectName) {
-        getRoute(notebookName, projectName)
+        getGatewayRoute("istio-system", "odh-dashboard")
           .then((route) => {
             if (cancelled) {
               return;
             }
-            setRoute(`https://${route.spec.host}/notebook/${projectName}/${notebookName}`);
+            setRoute(`https://${route?.spec.host}/notebook/${projectName}/${notebookName}/`);
             setLoadError(null);
             setLoaded(true);
           })

--- a/frontend/src/pages/projects/notebook/useRouteForNotebook.ts
+++ b/frontend/src/pages/projects/notebook/useRouteForNotebook.ts
@@ -10,6 +10,7 @@ const useRouteForNotebook = (
   const [loaded, setLoaded] = React.useState(false);
   const [loadError, setLoadError] = React.useState<Error | null>(null);
 
+  // ISTIO TODO: investigate where this is used, change link to istiofied.
   React.useEffect(() => {
     let watchHandle;
     let cancelled = false;

--- a/frontend/src/pages/projects/notebook/useRouteForNotebook.ts
+++ b/frontend/src/pages/projects/notebook/useRouteForNotebook.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { getGatewayRoute, getRoute } from '../../../api';
 import { FAST_POLL_INTERVAL } from '../../../utilities/const';
+import { useAppContext } from '../../../app/AppContext';
 
 const useRouteForNotebook = (
   notebookName?: string,
@@ -9,6 +10,7 @@ const useRouteForNotebook = (
   const [route, setRoute] = React.useState<string | null>(null);
   const [loaded, setLoaded] = React.useState(false);
   const [loadError, setLoadError] = React.useState<Error | null>(null);
+  const { dashboardConfig } = useAppContext();
 
   React.useEffect(() => {
     let watchHandle;
@@ -18,7 +20,12 @@ const useRouteForNotebook = (
         return;
       }
       if (notebookName && projectName) {
-        getGatewayRoute("istio-system", "odh-dashboard")
+        // execute getRoute if the feature flag is set to true
+        const getRoutePromise = dashboardConfig.spec.dashboardConfig.disableServiceMesh
+          ? getRoute(notebookName, projectName)
+          : getGatewayRoute("istio-system", "odh-gateway");
+
+        getRoutePromise
           .then((route) => {
             if (cancelled) {
               return;

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -19,7 +19,7 @@ import {
 } from './service';
 import { useUser } from '../../../../redux/selectors';
 import { ProjectDetailsContext } from '../../ProjectDetailsContext';
-import { AppContext } from '../../../../app/AppContext';
+import { AppContext, useAppContext } from '../../../../app/AppContext';
 import { fireTrackingEvent } from '../../../../utilities/segmentIOUtils';
 
 type SpawnerFooterProps = {
@@ -56,6 +56,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
     createInProgress ||
     !checkRequiredFieldsForNotebookStart(startNotebookData, storageData, envVariables);
   const { username } = useUser();
+  const { dashboardConfig } = useAppContext();
 
   const afterStart = (name: string, type: 'created' | 'updated') => {
     const { gpus, notebookSize, image } = startNotebookData;
@@ -103,7 +104,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
         envFrom,
         tolerationSettings,
       };
-      updateNotebook(editNotebook, newStartNotebookData, username)
+      updateNotebook(editNotebook, newStartNotebookData, username, dashboardConfig)
         .then((notebook) => afterStart(notebook.metadata.name, 'updated'))
         .catch(handleError);
     }
@@ -131,7 +132,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       tolerationSettings,
     };
 
-    createNotebook(newStartData, username)
+    createNotebook(newStartData, username, dashboardConfig)
       .then((notebook) => afterStart(notebook.metadata.name, 'created'))
       .catch(handleError);
   };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -71,6 +71,7 @@ export type DashboardCommonConfig = {
   disableUserManagement: boolean;
   disableProjects: boolean;
   disableModelServing: boolean;
+  disableServiceMesh: boolean;
   modelMetricsNamespace: string;
 };
 

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -210,8 +210,7 @@ export const useNotebookRedirectLink = (): (() => Promise<string>) => {
 
     return new Promise<string>((resolve, reject) => {
       const call = (resolve, reject) => {
-        // hardcoded get route to the odh-gateway
-        getRoute("istio-system", "opendatahub-odh-gateway-525eca1d5089dbdc")
+        getRoute(notebookNamespace, routeName)
           .then((route) => {
             resolve(`https://${route.spec.host}/notebook/${notebookNamespace}/${routeName}/`);
           })

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -210,9 +210,10 @@ export const useNotebookRedirectLink = (): (() => Promise<string>) => {
 
     return new Promise<string>((resolve, reject) => {
       const call = (resolve, reject) => {
-        getRoute(notebookNamespace, routeName)
+        // hardcoded get route to the odh-gateway
+        getRoute("istio-system", "opendatahub-odh-gateway-525eca1d5089dbdc")
           .then((route) => {
-            resolve(`https://${route.spec.host}/notebook/${notebookNamespace}/${routeName}`);
+            resolve(`https://${route.spec.host}/notebook/${notebookNamespace}/${routeName}/`);
           })
           .catch((e) => {
             if (backupRoute) {

--- a/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -45,6 +45,8 @@ spec:
                       type: boolean
                     disableModelServing:
                       type: boolean
+                    disableServiceMesh:
+                      type: boolean
                     modelMetricsNamespace:
                       type: string
                 groupsConfig:

--- a/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
+++ b/manifests/overlays/odhdashboardconfig/odh-dashboard-config.yaml
@@ -15,6 +15,7 @@ spec:
     enablement: true
     disableProjects: true
     disableModelServing: true
+    disableServiceMesh: true
     modelMetricsNamespace: ''
   notebookController:
     enabled: true


### PR DESCRIPTION
- adds the disableServiceMesh flag to all necessary parts of ODH-dashboard repo including docs. Defaults to `true` as it will be disabled by default.
- Uses disableServiceMesh flag to set `inject-oauth` annotation to `false` when using service mesh and `true` by default as injecting oauth-proxy is not necessary when using service mesh set up for SSO.
- Uses disableServiceMesh flag to link to the notebook through the service mesh gateway route when using service mesh and creating a notebook through the main jupyter tile.
- Uses disableServiceMesh flag to link to the notebook through the service mesh gateway route when using service mesh and creating a notebook ("workbench") through the Data Science project tab.


How to test:
- use my build of the ODH-operator that includes the disableServiceMesh flag as part of the ODHDashboardConfig. 

Do so by running `operator-sdk run bundle http://quay.io/cgarriso/opendatahub-operator-bundle:dev-0.0.1 --namespace $OPERATOR_NAMESPACE` (req operator-sdk v1.24.1 )

This should be all you need to deploy my build of the operator (not 100% sure).  

- Either build and push this dashboard image or use quay.io/maistra-dev/odh-dashboard:cam-test-proj-link. 
- To test the Data Science project piece without bartosz's changes to the the notebook-controller, create the DS project and manually add the SMM to the namespace. 