### PR TITLE
fix: use project controller created route for ds project routing

### DIFF
--- a/backend/src/routes/api/namespaces/namespaceUtils.ts
+++ b/backend/src/routes/api/namespaces/namespaceUtils.ts
@@ -64,7 +64,7 @@ export const applyNamespaceChange = async (
   const disableServiceMesh = getDashboardConfig().spec.dashboardConfig.disableServiceMesh;
 
   let labels = {};
-  let annotations = {}
+  let annotations = {};
   switch (context) {
     case NamespaceApplicationCase.DSG_CREATION:
       labels = {
@@ -73,7 +73,7 @@ export const applyNamespaceChange = async (
       };
       annotations = {
         'opendatahub.io/service-mesh': String(!disableServiceMesh),
-      }
+      };
       break;
     case NamespaceApplicationCase.MODEL_SERVING_PROMOTION:
       labels = {
@@ -85,9 +85,17 @@ export const applyNamespaceChange = async (
   }
 
   return fastify.kube.coreV1Api
-    .patchNamespace(name, { metadata: { labels, annotations } }, undefined, undefined, undefined, undefined, {
-      headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH },
-    })
+    .patchNamespace(
+      name,
+      { metadata: { labels, annotations } },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH },
+      },
+    )
     .then(() => ({ applied: true }))
     .catch((e) => {
       fastify.log.error(

--- a/backend/src/routes/api/notebooks/utils.ts
+++ b/backend/src/routes/api/notebooks/utils.ts
@@ -43,7 +43,12 @@ export const getNotebookStatus = async (
       });
     }
     if (route) {
-      newNotebook = await patchNotebookRoute(fastify, route.spec.host, namespace, notebookName).catch((e) => {
+      newNotebook = await patchNotebookRoute(
+        fastify,
+        route.spec.host,
+        namespace,
+        notebookName,
+      ).catch((e) => {
         fastify.log.warn(`Failed patching route to notebook ${notebookName}: ${e.message}`);
         return notebook;
       });

--- a/backend/src/routes/api/notebooks/utils.ts
+++ b/backend/src/routes/api/notebooks/utils.ts
@@ -43,7 +43,7 @@ export const getNotebookStatus = async (
       });
     }
     if (route) {
-      newNotebook = await patchNotebookRoute(fastify, route, namespace, notebookName).catch((e) => {
+      newNotebook = await patchNotebookRoute(fastify, route.spec.host, namespace, notebookName).catch((e) => {
         fastify.log.warn(`Failed patching route to notebook ${notebookName}: ${e.message}`);
         return notebook;
       });
@@ -82,14 +82,14 @@ export const checkPodContainersReady = (pod: V1Pod): boolean => {
 
 export const patchNotebookRoute = async (
   fastify: KubeFastifyInstance,
-  route: Route,
+  host: string,
   namespace: string,
   name: string,
 ): Promise<Notebook> => {
   const patch: RecursivePartial<Notebook> = {
     metadata: {
       annotations: {
-        'opendatahub.io/link': `https://${route.spec.host}/notebook/${namespace}/${name}/`,
+        'opendatahub.io/link': `https://${host}/notebook/${namespace}/${name}/`,
       },
     },
   };

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -389,7 +389,6 @@ export type Notebook = K8sResourceCommon & {
 
       // Openshift Service Mesh specific annotations. They're needed to orchestrate additional resources for nb namespaces.
       'opendatahub.io/service-mesh': string;
-      'opendatahub.io/hub-host': string;
 
       // TODO: Can we get this from the data in the Notebook??
       'notebooks.opendatahub.io/last-image-selection': string; // the last image they selected

--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -318,7 +318,6 @@ export const assembleNotebook = async (
         'notebooks.opendatahub.io/last-image-selection': imageSelection,
         'opendatahub.io/username': username,
         'opendatahub.io/service-mesh': serviceMeshEnabled,
-        'opendatahub.io/hub-host': url,
         'kubeflow-resource-stopped': null,
       },
       name: name,

--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -500,7 +500,6 @@ export const createNotebook = async (
   notebookAssembled.metadata.annotations['opendatahub.io/service-mesh'] = String(
     !config.spec.dashboardConfig.disableServiceMesh,
   );
-  notebookAssembled.metadata.annotations['opendatahub.io/hub-url'] = url;
 
   const notebookContainers = notebookAssembled.spec.template.spec.containers;
 

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -74,7 +74,6 @@ const assembleNotebook = (
         'opendatahub.io/service-mesh': String(
           !dashboardConfig.spec.dashboardConfig.disableServiceMesh,
         ),
-        'opendatahub.io/hub-url': origin,
         'opendatahub.io/username': username,
       },
       name: notebookId,

--- a/frontend/src/api/k8s/routes.ts
+++ b/frontend/src/api/k8s/routes.ts
@@ -1,6 +1,6 @@
 import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { RouteModel } from '~/api/models';
-import { K8sAPIOptions, RouteKind, List } from '~/k8sTypes';
+import { RouteModel, ProjectModel } from '~/api/models';
+import { K8sAPIOptions, RouteKind, ProjectKind } from '~/k8sTypes';
 import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
 
 export const getRoute = (
@@ -15,21 +15,10 @@ export const getRoute = (
     }),
   );
 
-export const getGatewayRoute = (
-  namespace: string,
-  gatewayName: string,
-): Promise<RouteKind | null> => {
-  const labelSelector = `maistra.io/gateway-name=${gatewayName}`;
+export const getServiceMeshGwHost = async (namespace: string): Promise<string | null> => {
   const queryOptions = {
     ns: namespace,
-    labelSelector,
   };
-  return k8sGetResource<List<RouteKind>>({ model: RouteModel, queryOptions })
-    .then((response) => {
-      const routes = response.items.filter(
-        (route) => route.metadata?.labels?.['maistra.io/gateway-name'] === gatewayName,
-      );
-      return routes.length > 0 ? routes[0] : null;
-    })
-    .catch(() => null);
+  const project = await k8sGetResource<ProjectKind>({ model: ProjectModel, queryOptions });
+  return project?.metadata?.annotations?.['opendatahub.io/service-mesh-gw-host'] || null;
 };

--- a/frontend/src/api/k8s/routes.ts
+++ b/frontend/src/api/k8s/routes.ts
@@ -17,7 +17,7 @@ export const getRoute = (
 
 export const getServiceMeshGwHost = async (namespace: string): Promise<string | null> => {
   const queryOptions = {
-    ns: namespace,
+    name: namespace,
   };
   const project = await k8sGetResource<NamespaceKind>({ model: NamespaceModel, queryOptions });
   return project?.metadata?.annotations?.['opendatahub.io/service-mesh-gw-host'] || null;

--- a/frontend/src/api/k8s/routes.ts
+++ b/frontend/src/api/k8s/routes.ts
@@ -1,6 +1,6 @@
 import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { RouteModel, ProjectModel } from '~/api/models';
-import { K8sAPIOptions, RouteKind, ProjectKind } from '~/k8sTypes';
+import { RouteModel, NamespaceModel } from '~/api/models';
+import { K8sAPIOptions, RouteKind, NamespaceKind } from '~/k8sTypes';
 import { applyK8sAPIOptions } from '~/api/apiMergeUtils';
 
 export const getRoute = (
@@ -19,6 +19,6 @@ export const getServiceMeshGwHost = async (namespace: string): Promise<string | 
   const queryOptions = {
     ns: namespace,
   };
-  const project = await k8sGetResource<ProjectKind>({ model: ProjectModel, queryOptions });
+  const project = await k8sGetResource<NamespaceKind>({ model: NamespaceModel, queryOptions });
   return project?.metadata?.annotations?.['opendatahub.io/service-mesh-gw-host'] || null;
 };

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -47,7 +47,6 @@ export type NotebookAnnotations = Partial<{
   'opendatahub.io/link': string; // redirect notebook url
   'opendatahub.io/username': string; // the untranslated username behind the notebook
   'opendatahub.io/service-mesh': string; // Openshift Service Mesh : determines if mesh configuration should be applied
-  'opendatahub.io/hub-url': string; // Openshift Service Mesh : holds origination host for authorization rules
   'notebooks.opendatahub.io/last-image-selection': string; // the last image they selected
   'notebooks.opendatahub.io/last-size-selection': string; // the last notebook size they selected
 }>;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -360,13 +360,6 @@ export type RouteKind = K8sResourceCommon & {
   };
 };
 
-export type List<T> = {
-  apiVersion?: string;
-  kind?: string;
-  metadata: Record<string, unknown>;
-  items: T[];
-} & K8sResourceCommon;
-
 export type SecretKind = K8sResourceCommon & {
   metadata: {
     name: string;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -238,6 +238,15 @@ export type ProjectKind = K8sResourceCommon & {
   };
 };
 
+export type NamespaceKind = K8sResourceCommon & {
+  metadata: {
+    annotations?: DisplayNameAnnotations;
+  };
+  status?: {
+    phase: 'Active' | 'Terminating';
+  };
+};
+
 export type ServiceAccountKind = K8sResourceCommon & {
   metadata: {
     annotations?: DisplayNameAnnotations;

--- a/frontend/src/pages/projects/notebook/useRouteForNotebook.ts
+++ b/frontend/src/pages/projects/notebook/useRouteForNotebook.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getGatewayRoute, getRoute } from '~/api';
+import { getServiceMeshGwHost, getRoute } from '~/api';
 import { FAST_POLL_INTERVAL } from '~/utilities/const';
 import { useAppContext } from '~/app/AppContext';
 
@@ -23,15 +23,15 @@ const useRouteForNotebook = (
       if (notebookName && projectName) {
         // if not using service mesh fetch openshift route, otherwise get Istio Ingress Gateway route
         const getRoutePromise = dashboardConfig.spec.dashboardConfig.disableServiceMesh
-          ? getRoute(notebookName, projectName)
-          : getGatewayRoute('istio-system', 'odh-gateway');
+          ? getRoute(notebookName, projectName).then((route) => route?.spec.host)
+          : getServiceMeshGwHost(projectName);
 
         getRoutePromise
-          .then((route) => {
+          .then((host) => {
             if (cancelled) {
               return;
             }
-            setRoute(`https://${route?.spec.host}/notebook/${projectName}/${notebookName}/`);
+            setRoute(`https://${host}/notebook/${projectName}/${notebookName}/`);
             setLoadError(null);
             setLoaded(true);
           })


### PR DESCRIPTION
Fixes issue where routing for data science project notebook links failed due to lack of permissions. Now it will fetch the route based on the namespace annotation 'opendatahub.io/service-mesh-gw-host' created by the `project-controller`.

