### PR TITLE
feat: use annotation to fetch host for notebook routing

### DIFF
--- a/backend/src/routes/api/notebooks/utils.ts
+++ b/backend/src/routes/api/notebooks/utils.ts
@@ -46,12 +46,7 @@ export const getNotebookStatus = async (
       }
     }
     if (host) {
-      newNotebook = await patchNotebookRoute(
-        fastify,
-        host,
-        namespace,
-        notebookName,
-      ).catch((e) => {
+      newNotebook = await patchNotebookRoute(fastify, host, namespace, notebookName).catch((e) => {
         fastify.log.warn(`Failed patching route to notebook ${notebookName}: ${e.message}`);
         return notebook;
       });

--- a/backend/src/routes/api/notebooks/utils.ts
+++ b/backend/src/routes/api/notebooks/utils.ts
@@ -10,7 +10,7 @@ import {
   getNamespaces,
   getNotebook,
   getRoute,
-  getGatewayRoute,
+  getServiceMeshGwHost,
   updateNotebook,
 } from '../../../utils/notebookUtils';
 import { FastifyRequest } from 'fastify';
@@ -30,22 +30,25 @@ export const getNotebookStatus = async (
   let newNotebook: Notebook;
   if (isRunning && !notebook?.metadata.annotations?.['opendatahub.io/link']) {
     const disableServiceMesh = getDashboardConfig().spec.dashboardConfig.disableServiceMesh;
-    let route: Route;
+    let host: string;
     if (!disableServiceMesh) {
-      route = await getGatewayRoute(fastify, 'istio-system', 'odh-gateway').catch((e) => {
+      host = await getServiceMeshGwHost(fastify, namespace).catch((e) => {
         fastify.log.warn(`Failed getting route ${notebookName}: ${e.message}`);
         return undefined;
       });
     } else {
-      route = await getRoute(fastify, namespace, notebookName).catch((e) => {
+      const route = await getRoute(fastify, namespace, notebookName).catch((e) => {
         fastify.log.warn(`Failed getting route ${notebookName}: ${e.message}`);
         return undefined;
       });
+      if (route) {
+        host = route.spec.host;
+      }
     }
-    if (route) {
+    if (host) {
       newNotebook = await patchNotebookRoute(
         fastify,
-        route.spec.host,
+        host,
         namespace,
         notebookName,
       ).catch((e) => {

--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -21,6 +21,7 @@ import { getUserName, usernameTranslate } from './userUtils';
 import { createCustomError } from './requestUtils';
 import {
   PatchUtils,
+  V1Namespace,
   V1PersistentVolumeClaim,
   V1Role,
   V1RoleBinding,
@@ -68,53 +69,37 @@ export const getRoute = async (
   return kubeResponse.body as Route;
 };
 
-interface RouteListResponse {
-  apiVersion: string;
-  kind: string;
-  metadata: {
-    resourceVersion: string;
-  };
-  items: Route[];
-}
-
-export const getGatewayRoute = async (
+export const getServiceMeshGwHost = async (
   fastify: KubeFastifyInstance,
   namespace: string,
-  gatewayName: string,
-): Promise<Route> => {
-  const selector = `maistra.io/gateway-name=${gatewayName}`;
-  const kubeResponse = await fastify.kube.customObjectsApi
-    .listNamespacedCustomObject(
-      'route.openshift.io',
-      'v1',
-      namespace,
-      'routes',
-      undefined,
-      undefined,
-      undefined,
-      selector,
-    )
+): Promise<string> => {
+  const kubeResponse = await fastify.kube.coreV1Api
+    .readNamespace(namespace)
     .catch((res) => {
       const e = res.response.body;
-      const error = createCustomError('Error getting Gateway Route', e.message, e.code);
+      const error = createCustomError('Error getting Namespace', e.message, e.code);
       fastify.log.error(error);
       throw error;
     });
 
   const body = kubeResponse.body as unknown;
-  const typedResponse = body as RouteListResponse;
+  const typedResponse = body as V1Namespace;
 
-  if (typedResponse.items.length === 0) {
+  const annotations = typedResponse.metadata?.annotations;
+
+  if (!annotations || !annotations['service-mesh.opendatahub.io/public-gateway-host-external']) {
     const error = createCustomError(
-      'Route not found',
-      `Could not find Route with label: ${selector}`,
+      'Annotation not found',
+      `Could not find annotation 'service-mesh.opendatahub.io/public-gateway-host-external' for namespace: ${namespace}`,
       404,
     );
     fastify.log.error(error);
     throw error;
   }
-  return typedResponse.items[0];
+
+  return annotations['service-mesh.opendatahub.io/public-gateway-host-external'];
 };
+
 
 export const createRBAC = async (
   fastify: KubeFastifyInstance,

--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -73,14 +73,12 @@ export const getServiceMeshGwHost = async (
   fastify: KubeFastifyInstance,
   namespace: string,
 ): Promise<string> => {
-  const kubeResponse = await fastify.kube.coreV1Api
-    .readNamespace(namespace)
-    .catch((res) => {
-      const e = res.response.body;
-      const error = createCustomError('Error getting Namespace', e.message, e.code);
-      fastify.log.error(error);
-      throw error;
-    });
+  const kubeResponse = await fastify.kube.coreV1Api.readNamespace(namespace).catch((res) => {
+    const e = res.response.body;
+    const error = createCustomError('Error getting Namespace', e.message, e.code);
+    fastify.log.error(error);
+    throw error;
+  });
 
   const body = kubeResponse.body as unknown;
   const typedResponse = body as V1Namespace;
@@ -99,7 +97,6 @@ export const getServiceMeshGwHost = async (
 
   return annotations['service-mesh.opendatahub.io/public-gateway-host-external'];
 };
-
 
 export const createRBAC = async (
   fastify: KubeFastifyInstance,

--- a/frontend/src/api/k8s/routes.ts
+++ b/frontend/src/api/k8s/routes.ts
@@ -20,5 +20,8 @@ export const getServiceMeshGwHost = async (namespace: string): Promise<string | 
     name: namespace,
   };
   const project = await k8sGetResource<NamespaceKind>({ model: NamespaceModel, queryOptions });
-  return project?.metadata?.annotations?.['service-mesh.opendatahub.io/public-gateway-host-external'] || null;
+  return (
+    project?.metadata?.annotations?.['service-mesh.opendatahub.io/public-gateway-host-external'] ||
+    null
+  );
 };

--- a/frontend/src/api/k8s/routes.ts
+++ b/frontend/src/api/k8s/routes.ts
@@ -20,5 +20,5 @@ export const getServiceMeshGwHost = async (namespace: string): Promise<string | 
     name: namespace,
   };
   const project = await k8sGetResource<NamespaceKind>({ model: NamespaceModel, queryOptions });
-  return project?.metadata?.annotations?.['opendatahub.io/service-mesh-gw-host'] || null;
+  return project?.metadata?.annotations?.['service-mesh.opendatahub.io/public-gateway-host-external'] || null;
 };


### PR DESCRIPTION
This PR updates the route fetching logic to use the new `"service-mesh.opendatahub.io/public-gateway-host-external"` namespace annotation when routing to a notebook. 

This prevents unnecessary route fetching from the `istio-system` namespace, and makes the logic between fetching a JupyterHub route from the main dashboard and from a Workbench created in a Data Science Project consistent. 