### PR TITLE
fix: patch notebook annotations

### DIFF
--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -298,6 +298,7 @@ export const assembleNotebook = async (
         'notebooks.opendatahub.io/oauth-logout-url': `${url}/notebookController/${translatedUsername}/home`,
         'notebooks.opendatahub.io/last-size-selection': notebookSize.name,
         'notebooks.opendatahub.io/last-image-selection': imageSelection,
+        'notebooks.opendatahub.io/inject-oauth': String(!serviceMeshEnabled),
         'opendatahub.io/username': username,
         'opendatahub.io/service-mesh': serviceMeshEnabled,
         'kubeflow-resource-stopped': null,

--- a/frontend/src/pages/projects/notebook/NotebookStatusToggle.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStatusToggle.tsx
@@ -102,6 +102,7 @@ const NotebookStatusToggle: React.FC<NotebookStatusToggleProps> = ({
                   notebookName,
                   notebookNamespace,
                   tolerationSettings,
+                  dashboardConfig,
                   enablePipelines && !currentlyHasPipelines(notebook),
                 ).then(() => {
                   fireNotebookTrackingEvent('started');


### PR DESCRIPTION
This PR changes behavior so that on notebook start in both dashboard ns and data science project ns, the service-mesh related annotations are updated.

This allows for migration of pre-existing notebooks when the disableServiceMesh flag is changed.

Tested on CRC 
- create notebook, stop notebook
- manually change annotations to sm=false, inject-oauth=true
- start notebook
- check annotations